### PR TITLE
Fix user login

### DIFF
--- a/lib/opensource_challenge_web/controllers/session_controller.ex
+++ b/lib/opensource_challenge_web/controllers/session_controller.ex
@@ -48,7 +48,7 @@ defmodule OpensourceChallengeWeb.SessionController do
       client = Github.OAuth2.get_token!(code: authorization_code)
       github_user = OAuth2.Client.get!(client, "/user").body
 
-      user = Repo.get_by!(User, github_login: github_user["login"])
+      user = Repo.get_by(User, github_login: github_user["login"])
 
       unless user do
         email =


### PR DESCRIPTION
The bug was introduced in commit #11f74e8

It is intended that the user may not be found in our database. Then it will be
created. The optimizations for Phoenix 1.3 included get_by! which errors when
the user can not be found.