### PR TITLE
Fix links to Phoenix framework documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ To start your Phoenix app:
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
-Ready to run in production? Please [check our deployment guides](http://www.phoenixframework.org/docs/deployment).
+Ready to run in production? Please [check the Phoenix deployment guide](https://hexdocs.pm/phoenix/deployment.html).
 
 ## Learn more
 
   * Official website: http://www.phoenixframework.org/
-  * Guides: http://phoenixframework.org/docs/overview
-  * Docs: https://hexdocs.pm/phoenix
+  * Documentation and installation guides: https://hexdocs.pm/phoenix/
   * Mailing list: http://groups.google.com/group/phoenix-talk
   * Source: https://github.com/phoenixframework/phoenix


### PR DESCRIPTION
Phoenix documentation was moved to hexdocs, there is no automatic redirects.
All entries under http://www.phoenixframework.org/docs return Error 404